### PR TITLE
Support msgctxt

### DIFF
--- a/specs/i18n.spec.js
+++ b/specs/i18n.spec.js
@@ -43,6 +43,7 @@ describe('i18n', () => {
   })
 
   describe('#translate', () => {
+    
     it('should return a plain string whenever possible', () => {
       const t = i18n('This is a __test__.', { test: 'success' })
       expect(t).to.be.a('string')
@@ -121,6 +122,26 @@ describe('i18n', () => {
 
         done()
       }).catch(done)
+    })
+
+    it('should consider the msgctxt option, if provided', (done) => {
+        setLocale('de_DE')
+
+        init(getLangLoader, config).then(() => {
+          expect(i18n('Export', {}, {msgctxt: 'button label'})).to.equal('Exportieren')
+
+          done()
+        }).catch(done)
+    })
+
+    it('should use the translation key without any msgctxt, if no msgctxt is provided', (done) => {
+        setLocale('de_DE')
+
+        init(getLangLoader, config).then(() => {
+          expect(i18n('Export')).to.equal('Exportiere')
+
+          done()
+        }).catch(done)
     })
   })
 })

--- a/specs/i18n.spec.js
+++ b/specs/i18n.spec.js
@@ -43,7 +43,7 @@ describe('i18n', () => {
   })
 
   describe('#translate', () => {
-    
+
     it('should return a plain string whenever possible', () => {
       const t = i18n('This is a __test__.', { test: 'success' })
       expect(t).to.be.a('string')
@@ -124,11 +124,11 @@ describe('i18n', () => {
       }).catch(done)
     })
 
-    it('should consider the msgctxt option, if provided', (done) => {
+    it('should consider the context option, if provided', (done) => {
         setLocale('de_DE')
 
         init(getLangLoader, config).then(() => {
-          expect(i18n('Export', {}, {msgctxt: 'button label'})).to.equal('Exportieren')
+          expect(i18n('Export', {context: 'button label'})).to.equal('Exportieren')
 
           done()
         }).catch(done)

--- a/specs/locales/de_DE.po
+++ b/specs/locales/de_DE.po
@@ -22,3 +22,10 @@ msgstr[1] "__count__ Kommentare"
 
 msgid "This is not translated"
 msgstr ""
+
+msgctxt "button label"
+msgid "Export"
+msgstr "Exportieren"
+
+msgid "Export"
+msgstr "Exportiere"

--- a/specs/locales/en_US.po
+++ b/specs/locales/en_US.po
@@ -22,3 +22,10 @@ msgstr[1] "__count__ comments"
 
 msgid "This is not translated"
 msgstr "This is not translated"
+
+msgctxt "button label"
+msgid "Export"
+msgstr "Export"
+
+msgid "Export"
+msgstr "Export"

--- a/src/translate.js
+++ b/src/translate.js
@@ -26,12 +26,14 @@ export default (singleton) => function translate(text, plural, options) {
   finalOptions = {
     ...defaultOptions,
     ...finalOptions,
+    msgctxt: options && options.msgctxt ? options.msgctxt + '%04' : '',
   }
 
+  console.log(finalOptions.msgctxt)
   const [
     translatedSingular,
     translatedPlural,
-  ] = (singleton.messages[text] || [null, null, null]).slice(1)
+  ] = (singleton.messages[unescape(finalOptions.msgctxt + text)] || [null, null, null]).slice(1)
 
   // find the raw translation message
   let translation

--- a/src/translate.js
+++ b/src/translate.js
@@ -26,14 +26,13 @@ export default (singleton) => function translate(text, plural, options) {
   finalOptions = {
     ...defaultOptions,
     ...finalOptions,
-    msgctxt: options && options.msgctxt ? options.msgctxt + '%04' : '',
+    context: finalOptions && finalOptions.context ? finalOptions.context + '%04' : '',
   }
 
-  console.log(finalOptions.msgctxt)
   const [
     translatedSingular,
     translatedPlural,
-  ] = (singleton.messages[unescape(finalOptions.msgctxt + text)] || [null, null, null]).slice(1)
+  ] = (singleton.messages[unescape(finalOptions.context + text)] || [null, null, null]).slice(1)
 
   // find the raw translation message
   let translation

--- a/src/translate.js
+++ b/src/translate.js
@@ -26,13 +26,13 @@ export default (singleton) => function translate(text, plural, options) {
   finalOptions = {
     ...defaultOptions,
     ...finalOptions,
-    context: finalOptions && finalOptions.context ? finalOptions.context + '%04' : '',
+    context: finalOptions && finalOptions.context ? finalOptions.context + '\u0004' : '',
   }
 
   const [
     translatedSingular,
     translatedPlural,
-  ] = (singleton.messages[unescape(finalOptions.context + text)] || [null, null, null]).slice(1)
+  ] = (singleton.messages[finalOptions.context + text] || [null, null, null]).slice(1)
 
   // find the raw translation message
   let translation


### PR DESCRIPTION
Adds message context support to i18n call script.
`i18n-extract` already supports message context.

Note:
* The way the .po file loader is handling message context is rather ugly, which impacts my implementation.
* I suppose we should add tests for `i18n-extract`. See: [babel-gettext-extractor tests](https://github.com/getsentry/babel-gettext-extractor/blob/master/test/test.js).