### PR TITLE
document: .i18nrc is conf file, not .babelrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,9 @@ Create the file `.i18nrc` and add a configuration object for gettext message ext
 
 ```json
 {
-  "extra": {
-    "gettext": {
-      "headers": "<POT_HEADERS>",
-      "fileName": "<PATH_TO_POT>",
-      "baseDirectory": "<PATH_TO_BASEDIR>"
-    }
-  }
+  "headers": "<POT_HEADERS>",
+  "fileName": "<PATH_TO_POT>",
+  "baseDirectory": "<PATH_TO_BASEDIR>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,18 @@ npm install --save signavio-i18n
 
 ## Setup
 
-Add the configuration for gettext message extraction to your `.babelrc`:
+Add a section like the following to your `packages.json`:
+
+```json
+{
+  "scripts": {
+    "i18n-init": "cd src/locales && msginit --no-translator --input messages.pot --locale",
+    "i18n": "i18n-extract \"src/**/*.js\" src/locales/messages.pot && i18n-merge src/locales/messages.pot src/locales/*.po"
+  }
+}
+```
+
+Create the file `.i18nrc` and add a configuration object for gettext message extraction:
 
 ```json
 {
@@ -34,17 +45,6 @@ Add the configuration for gettext message extraction to your `.babelrc`:
 
 All available options are documented here: https://github.com/getsentry/babel-gettext-extractor
 
-
-Add a section like the following to the `packages.json`:
-
-```json
-{
-  "scripts": {
-    "i18n-init": "cd src/locales && msginit --no-translator --input messages.pot --locale",
-    "i18n": "i18n-extract \"src/**/*.js\" src/locales/messages.pot && i18n-merge src/locales/messages.pot src/locales/*.po"
-  }
-}
-```
 
 ## Usage
 


### PR DESCRIPTION
Extracting msgids fails if no .i18nrc file is provided.

I re-ordered the setup items, because it seems that the .i18nrc file location depends on the path provided to `i18n-extract` (which I don't fully understand).