### PR TITLE
Shouldn't htmlEntities and htmlNumbers pass ?

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -184,7 +184,7 @@ export function escapeHtml(unsafe) {
   }
 
   // Used to match HTML entities and HTML characters.
-  const reUnescapedHtml = /[&<>"']/g
+  const reUnescapedHtml = /&(?![\w\#]+;)|[<>"']/g
   // Cast (null,undefined,[] and 0 to empty string => '')
   const reHasUnescapedHtml = RegExp(reUnescapedHtml.source)
 

--- a/test/specs/i18n.spec.js
+++ b/test/specs/i18n.spec.js
@@ -217,6 +217,13 @@ describe('i18n', () => {
       )
     })
 
+    it('should not escape html entities or html numbers', () => {
+      const str = '<div> & but also html entity_name &amp;<p> and &#60; are so called \'html entity_number"'
+      expect(escapeHtml(str)).toBe(
+        '&lt;div&gt; &amp; but also html entity_name &amp;&lt;p&gt; and &#60; are so called &#039;html entity_number&quot;'
+      )
+    })
+
     it('should handle undefined values with markdown', () => {
       expect(
         i18n(undefined, {


### PR DESCRIPTION
Just by change I looked at [this pr](https://github.com/signavio/i18n/pull/127) when was opened
and I asked myself whether or not the `escapeHtml` should ignore _htmlEntities_ and _htmlNumbers_

in case it should, this pr fixes it accordingly, changing the bare minimum.
actually that function could also be reduced to 
``` js 
export function escapeHtml(unsafe = ''){
  const htmlEscapes = {
    	'&': '&amp;',
    	'<': '&lt;',
    	'>': '&gt;',
    	'"': '&quot;',
    	"'": '&#039;',
  	}
  const rxt = /&(?![\w\#]+;)|[<>"']/g
  const rx = new RegExp(rxt);
  return rx.test(unsafe)
    ? unsafe.replace(rxt, e => htmlEscapes[e])
  	: unsafe
}
```

please let me know your thoughts on that