### PR TITLE
:tada: Allow updating messages, useful incase of multple lang sources

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,10 +136,10 @@ function loadBundle(resolve) {
   }
 
   const waitForLangChunk = tryToGetLangLoader(locale())
-  const updateLangMessages = tryToGetLangLoader(locale(), updateLangLoader)
 
   waitForLangChunk((messages) => {
-    if (updateLangMessages && updateLangLoader) {
+    if (updateLangLoader) {
+      const updateLangMessages = tryToGetLangLoader(locale(), updateLangLoader)
       singleton.messages = Object.assign({}, messages, updateLangMessages)
       updateLangLoader = undefined
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ function loadBundle(resolve) {
   const updateLangMessages = tryToGetLangLoader(locale(), updateLangLoader)
 
   waitForLangChunk((messages) => {
-    if (updateLangMessages) {
+    if (updateLangMessages && updateLangLoader) {
       singleton.messages = Object.assign({}, messages, updateLangMessages)
       updateLangLoader = undefined
     } else {


### PR DESCRIPTION
This PR is to address a situation where i18n language translations comes from multiple sources. Instead of calling `init` in library modules for example, we can simple utilise and update functions. This will ensure that i18n is initialise once in the main app, and the translation from the library module is updated afterward.  