### PR TITLE
feature: [DO NOT DELETE] [DO NOT MERGE] PEX-20271 replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Minimalist gettext style i18n for JavaScript
 - [Supports React components as interpolations](#interpolations)
 - [Pluralization support](#pluralization) (ngettext style)
 - [markdown support](#markdown)
+- [replacements support](#replacements)
 - Compatible with [webpack po-loader](https://github.com/perchlayer/po-loader)
 - Comes with scripts for extracting translation strings from JavaScript (Babel) sources and updating .pot and .po files
 
@@ -41,6 +42,9 @@ Create the file `.i18nrc` and add a configuration object for gettext message ext
   "baseDirectory": "<PATH_TO_BASEDIR>"
 }
 ```
+
+
+**IMPORTANT:**  when the second command line argument is passed to the `i18n-extract` command, it will overwrite the `fileName` field of the `.i18nrc` config.
 
 More available options are documented here: https://github.com/getsentry/babel-gettext-extractor
 
@@ -160,6 +164,77 @@ i18n('I want _this_ to be **bold**', {
   markdown: true,
 })
 ```
+
+### Replacements
+#### Extrtaction
+Sometimes there may be cases when you need to rename several entities across the whole project, but keep the both versions of translations and show them based on the feature flag.
+Doing that manually could be laborious, that's why `i18n-extract` supports a path to the replacements json as an optional third command line argument.
+
+```json
+{
+  "scripts": {
+    "i18n-init": "cd src/locales && msginit --no-translator --input messages.pot --locale",
+    "i18n": "i18n-extract \"src/**/*.js\" src/locales/messages.pot <PATH_TO_REPLACEMENTS_JSON> && i18n-merge src/locales/messages.pot src/locales/*.po"
+  }
+}
+```
+
+Replacements json file should be a simple object, where the keys are the original translation strings and the values are the new ones.
+
+```json
+{
+    "Old translation": "New translation",
+    "Old translation2": "New translation2"
+}
+```
+
+Having the original JS code: 
+```javascript
+// translators: comment 1
+i18n('Old translation');
+// translators: comment 2
+i18n('Old translation2');
+```
+
+The .pot file will have the following content
+
+```
+#. comment 1
+msgid "Old translation"
+msgstr ""
+
+#. comment 1 REPLACEMENT
+msgid "New translation"
+msgstr ""
+
+#. comment 2
+msgid "Old translation2"
+msgstr ""
+
+#. comment 2 REPLACEMENT
+msgid "New translation2"
+msgstr ""
+
+```
+
+#### Usage
+To use the replacements instead of the old strings in runtime pass the same replecements object which was used in the extraction step to the `init` function:
+
+```javascript
+import replacements from 'replacements.json'
+init(getLangLoader, config, replacements).then(() => {
+  // promise will be resolved when the translation bundle for the active locale has been loaded
+  alert(i18n('Hello world!'))
+  // >> Hello world!
+
+  // switch to another language
+  setLocale('de').then(() => {
+    alert(i18n('Hello world!'))
+    // >> Hallo Welt!
+  })
+})
+```
+
 
 [build-badge]: https://circleci.com/gh/signavio/i18n/tree/master.svg?style=shield&circle-token=:circle-token
 [build]: https://circleci.com/gh/signavio/i18n/tree/master

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The .pot file will have the following content
 msgid "Old translation"
 msgstr ""
 
-#. comment 1 REPLACEMENT
+#. comment 1 REPLACEMENT for "New translation"
 msgid "New translation"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Old translation2"
 msgstr ""
 
-#. comment 2 REPLACEMENT
+#. comment 2 REPLACEMENT for "New translation2"
 msgid "New translation2"
 msgstr ""
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ let changeLocaleListeners = []
 
 const singleton = {
   messages: {},
+  replacements: null,
   interpolationPattern: '__(\\w+)__',
 }
 
@@ -28,12 +29,13 @@ export default translate
  * @param configObj A hashmap with keys `default` (default locale) and `map` (mapping of locales to
  * other locales)
  **/
-export function init(getLangLoaderFn, configObj = {}) {
+export function init(getLangLoaderFn, configObj = {}, replacements) {
   getLangLoader = getLangLoaderFn
   config = configObj
   if (config.interpolationPattern) {
     singleton.interpolationPattern = configObj.interpolationPattern
   }
+  singleton.replacements = replacements 
   return new Promise(loadBundle)
 }
 
@@ -97,6 +99,7 @@ export function reset() {
   getLangLoader = undefined
 
   singleton.messages = {}
+  singleton.replacements = null
   changeLocaleListeners = []
 }
 

--- a/src/scripts/babel-gettext-extractor/index.js
+++ b/src/scripts/babel-gettext-extractor/index.js
@@ -233,9 +233,7 @@ export default function plugin() {
             ...translate,
             comments: {
               ...translate.comments,
-              extracted: (
-                (translate.comments.extracted || '').trim() + ` REPLACEMENT`
-              ).trim(),
+              extracted: (`REPLACEMENT for "${translate.msgid}"`).trim(),
             },
           }
 

--- a/src/scripts/extract.js
+++ b/src/scripts/extract.js
@@ -2,6 +2,7 @@
 import glob from 'glob'
 import ProgressBar from 'progress'
 import { transformFileSync } from '@babel/core'
+import fs from 'fs'
 import babelGettextExtractor from './babel-gettext-extractor'
 
 import getConfig from './config'
@@ -16,11 +17,28 @@ if (process.argv.length < 3) {
 
 // glob sync returns an array of filenames matching the pattern
 const files = glob.sync(process.argv[2])
+const outputfileName = process.argv[3]
+const replacementsJSONPath = process.argv[4]
+
+let replacements
+
+if (replacementsJSONPath) {
+  try {
+    replacements = JSON.parse(fs.readFileSync(replacementsJSONPath, 'utf8'))
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}
+
+
+
 
 const progressBar = new ProgressBar(' extracting [:bar] :percent :fileName', {
   total: files.length,
   width: 10,
 })
+
 
 files.forEach((fileName: string) => {
   // eslint-disable-next-line no-console
@@ -31,6 +49,6 @@ files.forEach((fileName: string) => {
 
   transformFileSync(fileName, {
     ...babel,
-    plugins: [...plugins, [babelGettextExtractor, config]],
+    plugins: [...plugins, [babelGettextExtractor, {...config, fileName: config.fileName || outputfileName, replacements}]],
   })
 })

--- a/src/translate.js
+++ b/src/translate.js
@@ -5,8 +5,21 @@ const defaultOptions = {
   markdown: false,
 }
 
+
 export default (singleton) => {
   return function translate(text, plural, options) {
+    // singleton.replacements optionally contains the translation replacements for the first two string arguments
+    if (singleton.replacements) {
+
+      if (typeof text === 'string' && singleton.replacements[text]) {
+        text = singleton.replacements[text]
+      }
+  
+      if (typeof plural === 'string' && singleton.replacements[plural]) {
+        plural = singleton.replacements[plural]
+      }
+    }
+
     // singleton.messages contains the translation messages for the currently active languae
     // format: singular key -> [ plural key, singular translations, plural translation ]
     let finalOptions = options

--- a/test/fixtures/replacements/.i18nrc
+++ b/test/fixtures/replacements/.i18nrc
@@ -1,0 +1,4 @@
+{
+  "fileName": "test/fixtures/replacements/messages.pot",
+  "baseDirectory": "test"
+}

--- a/test/fixtures/replacements/index.js
+++ b/test/fixtures/replacements/index.js
@@ -1,0 +1,3 @@
+i18n('Needs replacement')
+
+i18n('No replacement is needed')

--- a/test/fixtures/replacements/replacements.json
+++ b/test/fixtures/replacements/replacements.json
@@ -1,0 +1,3 @@
+{
+  "Needs replacement": "A replacement for 'Needs replacement'"
+}

--- a/test/specs/i18n.spec.js
+++ b/test/specs/i18n.spec.js
@@ -35,6 +35,40 @@ describe('i18n', () => {
     })
   })
 
+  describe('replacements', () => {
+    it('should use the corresponding trasnlation from the replacements object en_US', () => {
+      setLocale('en_US')
+      const replacements = {"Old translation": "New translation"}
+      return init(getLangLoader, {}, replacements).then(() => {
+        expect(i18n('Old translation')).toBe('New translation')
+      })
+    })
+
+    it('should use the corresponding trasnlation from the replacements object de_DE', () => {
+      setLocale('de_DE')
+      const replacements = {"Old translation": "New translation"}
+      return init(getLangLoader, {}, replacements).then(() => {
+        expect(i18n('Old translation')).toBe('Neue Übersetzung')
+      })
+    })
+
+    it('should not use the replaced translation when there are no match en_US)', () => {
+      setLocale('en_US')
+      const replacements = {"Foobar": "New translation"}
+      return init(getLangLoader, {}, replacements).then(() => {
+        expect(i18n('Old translation')).toBe('Old translation')
+      })
+    })
+
+    it('should not use the replaced translation when there are no match de_DE)', () => {
+      setLocale('de_DE')
+      const replacements = {"Foobar": "New translation"}
+      return init(getLangLoader, {}, replacements).then(() => {
+        expect(i18n('Old translation')).toBe('Alte Übersetzung')
+      })
+    })
+  })
+
   describe('#translate', () => {
     it('should return a plain string whenever possible', () => {
       const t = i18n('This is a __test__.', { test: 'success' })

--- a/test/specs/locales/de_DE.po
+++ b/test/specs/locales/de_DE.po
@@ -29,3 +29,9 @@ msgstr "Exportieren"
 
 msgid "Export"
 msgstr "Exportiere"
+
+msgid "Old translation"
+msgstr "Alte Übersetzung"
+
+msgid "New translation"
+msgstr "Neue Übersetzung"

--- a/test/specs/locales/en_US.po
+++ b/test/specs/locales/en_US.po
@@ -29,3 +29,9 @@ msgstr "Export"
 
 msgid "Export"
 msgstr "Export"
+
+msgid "Old translation"
+msgstr "Old translation"
+
+msgid "New translation"
+msgstr "New translation"

--- a/test/specs/scripts/extract.spec.js
+++ b/test/specs/scripts/extract.spec.js
@@ -15,6 +15,12 @@ const callForDir = dirName => {
   )
 }
 
+const callForDirReplacements = dirName => {
+  childProcess.execSync(
+    `node ${process.cwd()}/bin/i18n-extract.js "${dirName}/**/*.js" ${dirName}/messages.pot} ${dirName}/replacements.json`
+  )
+}
+
 describe('extract', () => {
   describe('function name', () => {
     const customFunctionNameDir = `${fixtureDir}/customFunctionName`
@@ -36,7 +42,30 @@ describe('extract', () => {
       expect(messages).not.toContain('msgid "Not in the result"')
     })
   })
+  
+  describe('replacements', () => {
+    const replacementsDir = `${fixtureDir}/replacements`
 
+    afterEach(() => {
+      removeIfExists(`${replacementsDir}/messages.pot`)
+    })
+
+    it('should be possible to add replacement translations based on the replacements json', () => {
+      expect(existsSync(`${replacementsDir}/messages.pot`)).toBeFalsy()
+
+      callForDirReplacements(replacementsDir)
+
+      expect(existsSync(`${replacementsDir}/messages.pot`)).toBeDefined()
+      
+      const messages = readFileSync(`${replacementsDir}/messages.pot`).toString("utf-8")
+
+      expect(messages).toContain('msgid "Needs replacement"')
+      expect(messages).toContain(`msgid "A replacement for 'Needs replacement'`)
+      expect(messages).toContain('#. REPLACEMENT')
+      expect(messages).toContain('msgid "No replacement is needed"')
+    })
+  })
+  
   describe('file name', () => {
     const customFileNameDir = `${fixtureDir}/customFileName`
 

--- a/test/specs/scripts/extract.spec.js
+++ b/test/specs/scripts/extract.spec.js
@@ -61,7 +61,7 @@ describe('extract', () => {
 
       expect(messages).toContain('msgid "Needs replacement"')
       expect(messages).toContain(`msgid "A replacement for 'Needs replacement'`)
-      expect(messages).toContain('#. REPLACEMENT')
+      expect(messages).toContain('#. REPLACEMENT for "Needs replacement"')
       expect(messages).toContain('msgid "No replacement is needed"')
     })
   })


### PR DESCRIPTION
[Related PR with use case ](https://github.com/signavio/pi-etl-client/pull/1624)

## Problem
Sometimes there may be cases when you need to rename several entities across the whole project, but keep the both versions of translations and show them based on the feature flag. Doing that manually  for each `i18n` could be laborious.


## Solution
The replacement feature provides:
- A way to generate `messages.pot` file with replacement translations
- A way to use those generated replacements in the runtime

More info is in the `Readme.md`

