### PR TITLE
Replacements no context extraction hotfix & tests

### DIFF
--- a/src/scripts/babel-gettext-extractor/index.js
+++ b/src/scripts/babel-gettext-extractor/index.js
@@ -226,7 +226,7 @@ export default function plugin() {
         context[translate.msgid] = translate
 
         if (replacements) {
-          const contextName = translate.msgctxt
+          const contextName = translate.msgctxt || ""
           const contextReplacements = replacements[contextName]
           if (
             contextReplacements &&

--- a/test/specs/scripts/extract.spec.js
+++ b/test/specs/scripts/extract.spec.js
@@ -59,8 +59,20 @@ describe('extract', () => {
       
       const messages = readFileSync(`${replacementsDir}/messages.pot`).toString("utf-8")
 
-      expect(messages).toContain('msgid "Needs replacement"')
-      expect(messages).toContain(`msgid "A replacement for 'Needs replacement'`)
+
+      expect(messages).toContain([
+        `#: fixtures/replacements/index.js:1`,
+        `msgid "Needs replacement"`,
+        `msgstr ""`,
+      ].join('\n'))
+
+      expect(messages).toContain([
+        `#: fixtures/replacements/index.js:1`,
+        `#. REPLACEMENT for "Needs replacement"`,
+        `msgid "A replacement for 'Needs replacement'"`,
+        `msgstr ""`,
+      ].join('\n'))
+
       expect(messages).toContain('#. REPLACEMENT for "Needs replacement"')
       expect(messages).toContain('msgid "No replacement is needed"')
 


### PR DESCRIPTION
## Problem
Replacements from `replacements.json` without config were not extracted to the `messages.pot`