### PR TITLE
SIGSPM-13231 exclude yarn.lock from cx scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
             --tenant $CX_TENANT \
             --client-id $CX_CLIENT_ID \
             --client-secret $CX_CLIENT_SECRET \
+            --file-filter '!**/yarn.lock' \
 
   test:
     executor: node


### PR DESCRIPTION
cx is scanning yarn.lock and create 900+ hard coded warnings.