### PR TITLE
Allow il8n to be used with react 18 and 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0",
-    "react": "^16.13.0"
+    "react": "^16.13.0 || ^18.3.1 || ^19.0.0"
   },
   "resolutions": {
     "set-value": "^4.1.0",


### PR DESCRIPTION
**What has changes**
I have changed the peerDependencies of this dependency to support react version 18 and 19. 
currently the package.json specifies i18n can only be used with applications with react 16 

**Why** 
It's causing multiple pipelines in SPG to fail due to unmet dependencies 

**Risks**
i18n works with react 18, SPG have been using it for a while. I can test it but haven't tested react 19. I just assume it will work but don't want to block future experiments.
